### PR TITLE
Fix assertion requires

### DIFF
--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -1,3 +1,4 @@
+require "rails"
 require "minitest/rails/controller"
 require "minitest/rails/fixtures"
 require "minitest/rails/helper"


### PR DESCRIPTION
I was getting NameError on ActiveSupport::Conern previously
I think you could replace it with just the top three requires anyways, as they're set to autoload the assertions
But I don't think you can require those files specifically, the high-level files have most of their requires
