### PR TITLE
Detect ActiveRecord, Mongoid, MongoMapper, DataMapper for model spec type registration

### DIFF
--- a/lib/minitest/rails/model.rb
+++ b/lib/minitest/rails/model.rb
@@ -11,6 +11,6 @@ module MiniTest
 end
 
 MiniTest::Spec.register_spec_type MiniTest::Rails::Model do |desc|
-  desc.respond_to? :ancestors && !(desc.ancestors.map(&:to_s) & ["ActiveRecord::Base", "Mongoid::Document", "MongoMapper::Document", "DataMapper::Resource"]).empty?
+  desc.respond_to?(:ancestors) && !(desc.ancestors.map(&:to_s) & ["ActiveRecord::Base", "Mongoid::Document", "MongoMapper::Document", "DataMapper::Resource"]).empty?
 end
 

--- a/lib/minitest/rails/model.rb
+++ b/lib/minitest/rails/model.rb
@@ -11,6 +11,6 @@ module MiniTest
 end
 
 MiniTest::Spec.register_spec_type MiniTest::Rails::Model do |desc|
-  !(desc.ancestors.map(&:to_s) & ["ActiveRecord::Base", "Mongoid::Document", "MongoMapper::Document", "DataMapper::Resource"]).empty?
+  desc.respond_to? :ancestors && !(desc.ancestors.map(&:to_s) & ["ActiveRecord::Base", "Mongoid::Document", "MongoMapper::Document", "DataMapper::Resource"]).empty?
 end
 

--- a/lib/minitest/rails/model.rb
+++ b/lib/minitest/rails/model.rb
@@ -11,9 +11,6 @@ module MiniTest
 end
 
 MiniTest::Spec.register_spec_type MiniTest::Rails::Model do |desc|
-  begin
-    desc < ActiveRecord::Base
-  rescue ArgumentError
-  end
+  !(desc.ancestors.map(&:to_s) & ["ActiveRecord::Base", "Mongoid::Document", "MongoMapper::Document", "DataMapper::Resource"]).empty?
 end
 


### PR DESCRIPTION
Currently, you're checking to see if desc is a subclass of ActiveRecord::Base. I'm using Mongoid in my app so this causes:

lib/minitest/rails/model.rb:15:in `block in <top (required)>': uninitialized constant ActiveRecord (NameError)

This change checks the desc ancestors to see if they include ActiveRecord, Mongoid, MongoMapper or DataMapper modules. If they do, then register the spec.
