### PR TITLE
Fix nested describe blocks and incorrect controller_name in Controller specs

### DIFF
--- a/lib/minitest/rails/controller.rb
+++ b/lib/minitest/rails/controller.rb
@@ -8,6 +8,17 @@ module MiniTest
       include ActiveSupport::Testing::SetupAndTeardown
       include ActionController::TestCase::Behavior
 
+      # Rails 3.2 determines the controller class by matching class names that end in Test
+      # This overides the #determine_default_controller_class method to allow you use Controller
+      # class names in your describe argument
+      def self.determine_default_controller_class(name)
+        if name.match(/.*(?:^|::)(\w+Controller)/)
+          $1.safe_constantize
+        else
+          super(name)
+        end
+      end
+
       before do
         @controller = self.class.name.match(/((.*)Controller)/)[1].constantize.new
         @routes     = ::Rails.application.routes
@@ -21,4 +32,3 @@ module MiniTest
 end
 
 MiniTest::Spec.register_spec_type /Controller/, MiniTest::Rails::Controller
-


### PR DESCRIPTION
In Rails 3.2, nested describe blocks cause a NameError Exception. This is caused by the `#determine_default_controller_class` method in `actionpack-3.2.2/lib/action_controller/test_case.rb`. The method contains a regex that looks for a name ending in "Test", which is the Rails functional test convention. In minitest-spec you're more likely to use:

``` ruby
describe ApplicationController do
...
end
```

rather than `ApplicationControllerTest`, which would raise an exception anyway since it's not defined. This patch overrides `#determine_default_controller_class` and returns the last controller name in the nested describe chain so that the controller_name in the testcase is set correctly.

I don't know how common it is that anyone would have 2 controllers blocks, one nested within the other, so I opted to pick the right most controller name.
